### PR TITLE
feat(runner): support FARGATE_SPOT

### DIFF
--- a/API.md
+++ b/API.md
@@ -4,8 +4,8 @@
 
 Name|Description
 ----|-----------
-[FargateJobExecutor](#cdk-gitlab-fargatejobexecutor)|*No description*
-[FargateRunner](#cdk-gitlab-fargaterunner)|*No description*
+[FargateJobExecutor](#cdk-gitlab-fargatejobexecutor)|The FargateJobExecutor.
+[FargateRunner](#cdk-gitlab-fargaterunner)|The FargateRunner.
 [JobExecutorImage](#cdk-gitlab-jobexecutorimage)|The docker image for the job executor.
 [Provider](#cdk-gitlab-provider)|The Provider to create GitLab Integrations with AWS.
 
@@ -14,18 +14,26 @@ Name|Description
 
 Name|Description
 ----|-----------
+[CapacityProviderStrategyItem](#cdk-gitlab-capacityproviderstrategyitem)|The Capacity Provider strategy.
 [EksClusterOptions](#cdk-gitlab-eksclusteroptions)|*No description*
 [FargateEksClusterOptions](#cdk-gitlab-fargateeksclusteroptions)|*No description*
-[FargateJobExecutorProps](#cdk-gitlab-fargatejobexecutorprops)|*No description*
-[FargateRunnerProps](#cdk-gitlab-fargaterunnerprops)|*No description*
+[FargateJobExecutorProps](#cdk-gitlab-fargatejobexecutorprops)|The properties for the FargateJobExecutor.
+[FargateRunnerProps](#cdk-gitlab-fargaterunnerprops)|Properties for the FargateRunner.
 [ProviderProps](#cdk-gitlab-providerprops)|*No description*
 [RoleProps](#cdk-gitlab-roleprops)|*No description*
+
+
+**Enums**
+
+Name|Description
+----|-----------
+[FargateCapacityProviderType](#cdk-gitlab-fargatecapacityprovidertype)|Amazon ECS Capacity Providers for AWS Fargate.
 
 
 
 ## class FargateJobExecutor  <a id="cdk-gitlab-fargatejobexecutor"></a>
 
-
+The FargateJobExecutor.
 
 __Implements__: [IConstruct](#constructs-iconstruct), [IConstruct](#aws-cdk-core-iconstruct), [IConstruct](#constructs-iconstruct), [IDependable](#aws-cdk-core-idependable)
 __Extends__: [Construct](#aws-cdk-core-construct)
@@ -65,7 +73,7 @@ Name | Type | Description
 
 ## class FargateRunner  <a id="cdk-gitlab-fargaterunner"></a>
 
-
+The FargateRunner.
 
 __Implements__: [IConstruct](#constructs-iconstruct), [IConstruct](#aws-cdk-core-iconstruct), [IConstruct](#constructs-iconstruct), [IDependable](#aws-cdk-core-idependable)
 __Extends__: [Construct](#aws-cdk-core-construct)
@@ -83,11 +91,13 @@ new FargateRunner(scope: Construct, id: string, props: FargateRunnerProps)
 * **id** (<code>string</code>)  *No description*
 * **props** (<code>[FargateRunnerProps](#cdk-gitlab-fargaterunnerprops)</code>)  *No description*
   * **vpc** (<code>[IVpc](#aws-cdk-aws-ec2-ivpc)</code>)  VPC for the fargate. 
+  * **clusterDefaultCapacityProviderStrategy** (<code>Array<[CapacityProviderStrategyItem](#cdk-gitlab-capacityproviderstrategyitem)></code>)  Default capacity provider strategy for the Amazon ECS cluster. __*Default*__: DEFAULT_CLUSTER_CAPACITY_PROVIDER_STRATEGY
   * **executor** (<code>[FargateJobExecutor](#cdk-gitlab-fargatejobexecutor)</code>)  Fargate job executor options. __*Optional*__
   * **fargateJobSubnet** (<code>[SubnetSelection](#aws-cdk-aws-ec2-subnetselection)</code>)  subnet for fargate CI task. __*Optional*__
   * **gitlabURL** (<code>string</code>)  gitlab URL prefix. __*Default*__: 'https://gitlab.com'
   * **registrationToken** (<code>string</code>)  GitLab registration token for the runner. __*Optional*__
   * **securityGroup** (<code>[ISecurityGroup](#aws-cdk-aws-ec2-isecuritygroup)</code>)  The security group for Fargate CI task. __*Optional*__
+  * **serviceDefaultCapacityProviderStrategy** (<code>Array<[CapacityProviderStrategyItem](#cdk-gitlab-capacityproviderstrategyitem)></code>)  Default capacity provider strategy for the Amazon ECS service. __*Default*__: DEFAULT_SERVICE_CAPACITY_PROVIDER_STRATEGY
   * **tags** (<code>Array<string></code>)  tags for the runner. __*Optional*__
 
 
@@ -257,6 +267,21 @@ __Returns__:
 
 
 
+## struct CapacityProviderStrategyItem  <a id="cdk-gitlab-capacityproviderstrategyitem"></a>
+
+
+The Capacity Provider strategy.
+
+
+
+Name | Type | Description 
+-----|------|-------------
+**capacityProvider** | <code>[FargateCapacityProviderType](#cdk-gitlab-fargatecapacityprovidertype)</code> | <span></span>
+**weight** | <code>number</code> | <span></span>
+**base**? | <code>number</code> | __*Optional*__
+
+
+
 ## struct EksClusterOptions  <a id="cdk-gitlab-eksclusteroptions"></a>
 
 
@@ -288,7 +313,7 @@ Name | Type | Description
 ## struct FargateJobExecutorProps  <a id="cdk-gitlab-fargatejobexecutorprops"></a>
 
 
-
+The properties for the FargateJobExecutor.
 
 
 
@@ -305,18 +330,20 @@ Name | Type | Description
 ## struct FargateRunnerProps  <a id="cdk-gitlab-fargaterunnerprops"></a>
 
 
-
+Properties for the FargateRunner.
 
 
 
 Name | Type | Description 
 -----|------|-------------
 **vpc** | <code>[IVpc](#aws-cdk-aws-ec2-ivpc)</code> | VPC for the fargate.
+**clusterDefaultCapacityProviderStrategy**? | <code>Array<[CapacityProviderStrategyItem](#cdk-gitlab-capacityproviderstrategyitem)></code> | Default capacity provider strategy for the Amazon ECS cluster.<br/>__*Default*__: DEFAULT_CLUSTER_CAPACITY_PROVIDER_STRATEGY
 **executor**? | <code>[FargateJobExecutor](#cdk-gitlab-fargatejobexecutor)</code> | Fargate job executor options.<br/>__*Optional*__
 **fargateJobSubnet**? | <code>[SubnetSelection](#aws-cdk-aws-ec2-subnetselection)</code> | subnet for fargate CI task.<br/>__*Optional*__
 **gitlabURL**? | <code>string</code> | gitlab URL prefix.<br/>__*Default*__: 'https://gitlab.com'
 **registrationToken**? | <code>string</code> | GitLab registration token for the runner.<br/>__*Optional*__
 **securityGroup**? | <code>[ISecurityGroup](#aws-cdk-aws-ec2-isecuritygroup)</code> | The security group for Fargate CI task.<br/>__*Optional*__
+**serviceDefaultCapacityProviderStrategy**? | <code>Array<[CapacityProviderStrategyItem](#cdk-gitlab-capacityproviderstrategyitem)></code> | Default capacity provider strategy for the Amazon ECS service.<br/>__*Default*__: DEFAULT_SERVICE_CAPACITY_PROVIDER_STRATEGY
 **tags**? | <code>Array<string></code> | tags for the runner.<br/>__*Optional*__
 
 
@@ -346,5 +373,15 @@ Name | Type | Description
 **accountId** | <code>string</code> | <span></span>
 **externalId** | <code>string</code> | <span></span>
 
+
+
+## enum FargateCapacityProviderType  <a id="cdk-gitlab-fargatecapacityprovidertype"></a>
+
+Amazon ECS Capacity Providers for AWS Fargate.
+
+Name | Description
+-----|-----
+**FARGATE** |
+**FARGATE_SPOT** |
 
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ provider.createEc2Runner(...);
 });
 ```
 
+# Fargate Runner with Aamzon ECS
+
+On deployment with `createFargateRunner()`, the **Fargate Runner** will be provisioned in Amazon ECS with AWS Fargate and [Amazon ECS Capacity Providers](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cluster-capacity-providers.html). By default, the `FARGATE` and `FARGATE_SPOT` capacity providers are available for the Amazon ECS cluster and the runner and job executor will run on `FARGATE_SPOT`. You can specify your custom `clusterDefaultCapacityProviderStrategy` and `serviceDefaultCapacityProviderStrategy` properties from the `FargateRunner` construct for different capacity provider strategies.
+
+
 # Deploy
 
 

--- a/src/integ.default.ts
+++ b/src/integ.default.ts
@@ -3,10 +3,10 @@ import * as eks from '@aws-cdk/aws-eks';
 import * as cdk from '@aws-cdk/core';
 import { Provider, FargateJobExecutor, FargateRunner, JobExecutorImage } from './';
 
-
 export interface IntegTestingProps {
   readonly vpc?: ec2.IVpc;
 }
+
 export class IntegTesting {
   readonly stack: cdk.Stack[];
   constructor(props: IntegTestingProps = {}) {
@@ -19,7 +19,7 @@ export class IntegTesting {
 
     const stack = new cdk.Stack(app, 'integ-stack', { env });
 
-    const vpc = props.vpc ?? new ec2.Vpc(stack, 'Vpc', { natGateways: 1 });
+    const vpc = props.vpc ?? getOrCreateVpc(stack);
 
     const provider = new Provider(stack, 'GitlabProvider', { vpc });
 
@@ -53,3 +53,13 @@ export class IntegTesting {
 process.env.GITLAB_REGISTRATION_TOKEN='mock';
 
 new IntegTesting();
+
+
+function getOrCreateVpc(scope: cdk.Construct): ec2.IVpc {
+  // use an existing vpc or create a new one
+  return scope.node.tryGetContext('use_default_vpc') === '1' ?
+    ec2.Vpc.fromLookup(scope, 'Vpc', { isDefault: true }) :
+    scope.node.tryGetContext('use_vpc_id') ?
+      ec2.Vpc.fromLookup(scope, 'Vpc', { vpcId: scope.node.tryGetContext('use_vpc_id') }) :
+      new ec2.Vpc(scope, 'Vpc', { maxAzs: 3, natGateways: 1 });
+}

--- a/test/__snapshots__/integ.snapshot.test.ts.snap
+++ b/test/__snapshots__/integ.snapshot.test.ts.snap
@@ -312,6 +312,19 @@ Object {
       "Type": "AWS::IAM::Role",
     },
     "FargateRunnerClusterFFA572F1": Object {
+      "Properties": Object {
+        "CapacityProviders": Array [
+          "FARGATE",
+          "FARGATE_SPOT",
+        ],
+        "DefaultCapacityProviderStrategy": Array [
+          Object {
+            "base": 0,
+            "capacityProvider": "FARGATE_SPOT",
+            "weight": 1,
+          },
+        ],
+      },
       "Type": "AWS::ECS::Cluster",
     },
     "FargateRunnerFargateSecurityGroupC01BE5FB": Object {
@@ -351,6 +364,17 @@ Object {
     },
     "FargateRunnerRunnerManagerService6E98525F": Object {
       "Properties": Object {
+        "CapacityProviderStrategy": Array [
+          Object {
+            "base": 0,
+            "capacityProvider": "FARGATE",
+            "weight": 0,
+          },
+          Object {
+            "capacityProvider": "FARGATE_SPOT",
+            "weight": 1,
+          },
+        ],
         "Cluster": Object {
           "Ref": "FargateRunnerClusterFFA572F1",
         },
@@ -360,7 +384,6 @@ Object {
         },
         "DesiredCount": 1,
         "EnableECSManagedTags": false,
-        "LaunchType": "FARGATE",
         "NetworkConfiguration": Object {
           "AwsvpcConfiguration": Object {
             "AssignPublicIp": "DISABLED",
@@ -1222,6 +1245,19 @@ Object {
       "UpdateReplacePolicy": "Delete",
     },
     "GitlabProviderFargateRunnerCluster69894B32": Object {
+      "Properties": Object {
+        "CapacityProviders": Array [
+          "FARGATE",
+          "FARGATE_SPOT",
+        ],
+        "DefaultCapacityProviderStrategy": Array [
+          Object {
+            "base": 0,
+            "capacityProvider": "FARGATE_SPOT",
+            "weight": 1,
+          },
+        ],
+      },
       "Type": "AWS::ECS::Cluster",
     },
     "GitlabProviderFargateRunnerFargateSecurityGroup83A59793": Object {
@@ -1379,6 +1415,17 @@ Object {
     },
     "GitlabProviderFargateRunnerRunnerManagerService95EFD79A": Object {
       "Properties": Object {
+        "CapacityProviderStrategy": Array [
+          Object {
+            "base": 0,
+            "capacityProvider": "FARGATE",
+            "weight": 0,
+          },
+          Object {
+            "capacityProvider": "FARGATE_SPOT",
+            "weight": 1,
+          },
+        ],
         "Cluster": Object {
           "Ref": "GitlabProviderFargateRunnerCluster69894B32",
         },
@@ -1388,7 +1435,6 @@ Object {
         },
         "DesiredCount": 1,
         "EnableECSManagedTags": false,
-        "LaunchType": "FARGATE",
         "NetworkConfiguration": Object {
           "AwsvpcConfiguration": Object {
             "AssignPublicIp": "DISABLED",


### PR DESCRIPTION
- Support `FARGATE_SPOT` for the fargate runner on Amazon ECS.
- All fargate runners and executors will run on `FARGATE_SPOT` by default
- `clusterDefaultCapacityProviderStrategy` and `serviceDefaultCapacityProviderStrategy` to customize the capacity provider strategy for cluster and service


Fixes #21 